### PR TITLE
Add missing header files

### DIFF
--- a/memeat.c
+++ b/memeat.c
@@ -1,8 +1,10 @@
 #include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/mman.h>
 #include <sys/resource.h>
+#include <unistd.h>
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
A couple header files that should be included are missing.
Without them this throws warnings when compiling via clang.